### PR TITLE
Disable non session related commands when a session is started

### DIFF
--- a/src/main/java/seedu/zerotoone/logic/commands/Command.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/Command.java
@@ -7,6 +7,7 @@ import seedu.zerotoone.model.Model;
  * Represents a command with hidden internal logic and the ability to be executed.
  */
 public abstract class Command {
+    public static final String MESSAGE_SESSION_STARTED = "Finish your workout session before trying this command!";
 
     /**
      * Executes the command and returns the result message.

--- a/src/main/java/seedu/zerotoone/logic/commands/DoneCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/DoneCommand.java
@@ -29,7 +29,7 @@ public class DoneCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (!model.isInSession()) {
-            throw new CommandException((MESSAGE_NOT_STARTED));
+            throw new CommandException(MESSAGE_NOT_STARTED);
         }
 
         LocalDateTime currentDateTime = LocalDateTime.now();

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/CreateCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/CreateCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -36,6 +37,10 @@ public class CreateCommand extends ExerciseCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         Exercise exercise = new Exercise(this.exerciseName, this.exerciseSets);
 
         if (model.hasExercise(exercise)) {

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/DeleteCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/DeleteCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -28,6 +29,10 @@ public class DeleteCommand extends ExerciseCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Exercise> lastShownList = model.getFilteredExerciseList();
 
         if (exerciseId.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/EditCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/EditCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -40,6 +41,10 @@ public class EditCommand extends ExerciseCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Exercise> lastShownList = model.getFilteredExerciseList();
         if (exerciseId.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_INDEX);

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/FindCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/FindCommand.java
@@ -2,7 +2,9 @@ package seedu.zerotoone.logic.commands.exercise;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 import seedu.zerotoone.model.exercise.ExerciseName;
 import seedu.zerotoone.model.exercise.PredicateFilterExerciseName;
@@ -23,8 +25,12 @@ public class FindCommand extends ExerciseCommand {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         PredicateFilterExerciseName predicate = new PredicateFilterExerciseName(exerciseName.fullName);
 
         model.updateFilteredExerciseList(predicate);

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/ListCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/ListCommand.java
@@ -3,7 +3,9 @@ package seedu.zerotoone.logic.commands.exercise;
 import static java.util.Objects.requireNonNull;
 import static seedu.zerotoone.model.Model.PREDICATE_SHOW_ALL_EXERCISES;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 
 /**
@@ -15,8 +17,11 @@ public class ListCommand extends ExerciseCommand {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
         model.updateFilteredExerciseList(PREDICATE_SHOW_ALL_EXERCISES);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/set/AddCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/set/AddCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -45,6 +46,10 @@ public class AddCommand extends SetCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Exercise> lastShownList = model.getFilteredExerciseList();
 
         if (exerciseId.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/set/DeleteCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/set/DeleteCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -36,6 +37,10 @@ public class DeleteCommand extends SetCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Exercise> lastShownList = model.getFilteredExerciseList();
 
         if (exerciseId.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/exercise/set/EditCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/exercise/set/EditCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -48,6 +49,10 @@ public class EditCommand extends SetCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Exercise> lastShownList = model.getFilteredExerciseList();
         if (exerciseId.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_INDEX);

--- a/src/main/java/seedu/zerotoone/logic/commands/log/DeleteCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/log/DeleteCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -29,6 +30,10 @@ public class DeleteCommand extends LogCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<CompletedWorkout> lastShownList = model.getFilteredLogList();
 
         if (logId.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/log/DisplayCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/log/DisplayCommand.java
@@ -5,7 +5,9 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 
 /**
@@ -26,8 +28,11 @@ public class DisplayCommand extends LogCommand {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
 
         model.setStatisticsDateRange(startRange, endRage);
         return new CommandResult(MESSAGE_SUCCESS, false, true, false);

--- a/src/main/java/seedu/zerotoone/logic/commands/log/FindCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/log/FindCommand.java
@@ -6,7 +6,9 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 import seedu.zerotoone.model.log.PredicateFilterLogWorkoutName;
 import seedu.zerotoone.model.session.CompletedWorkout;
@@ -35,8 +37,12 @@ public class FindCommand extends LogCommand {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         Predicate<CompletedWorkout> predicate = session -> true;
 
         if (workoutNameOptional.isPresent()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/log/ListCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/log/ListCommand.java
@@ -3,7 +3,9 @@ package seedu.zerotoone.logic.commands.log;
 import static java.util.Objects.requireNonNull;
 import static seedu.zerotoone.model.Model.PREDICATE_SHOW_ALL_LOGS;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 
 /**
@@ -15,8 +17,12 @@ public class ListCommand extends LogCommand {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         model.updateFilteredLogList(PREDICATE_SHOW_ALL_LOGS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/zerotoone/logic/commands/schedule/CreateCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/schedule/CreateCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -38,6 +39,10 @@ public class CreateCommand extends ScheduleCommand {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         if (!DateTime.isDateEqualOrLaterThanToday(dateTime)) {
             throw new CommandException(MESSAGE_DATETIME_IN_THE_PAST);
         }

--- a/src/main/java/seedu/zerotoone/logic/commands/schedule/DeleteCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/schedule/DeleteCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -28,6 +29,10 @@ public class DeleteCommand extends ScheduleCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<ScheduledWorkout> lastShownList = model.getSortedScheduledWorkoutList();
 
         if (scheduledWorkoutId.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/schedule/EditCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/schedule/EditCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -41,6 +42,10 @@ public class EditCommand extends ScheduleCommand {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         if (!DateTime.isDateEqualOrLaterThanToday(dateTime)) {
             throw new CommandException(MESSAGE_DATETIME_IN_THE_PAST);
         }

--- a/src/main/java/seedu/zerotoone/logic/commands/schedule/ListCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/schedule/ListCommand.java
@@ -2,6 +2,7 @@ package seedu.zerotoone.logic.commands.schedule;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -16,6 +17,9 @@ public class ListCommand extends ScheduleCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
 
         model.populateSortedScheduledWorkoutList();
 

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/CreateCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/CreateCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -36,6 +37,10 @@ public class CreateCommand extends WorkoutCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         Workout workout = new Workout(this.workoutName, this.workoutExercises);
 
         if (model.hasWorkout(workout)) {

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/DeleteCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/DeleteCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -28,6 +29,10 @@ public class DeleteCommand extends WorkoutCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Workout> lastShownList = model.getFilteredWorkoutList();
 
         if (workoutId.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/EditCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/EditCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -40,6 +41,10 @@ public class EditCommand extends WorkoutCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Workout> lastShownList = model.getFilteredWorkoutList();
         if (workoutId.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_INDEX);

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/FindCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/FindCommand.java
@@ -2,7 +2,9 @@ package seedu.zerotoone.logic.commands.workout;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 import seedu.zerotoone.model.workout.PredicateFilterWorkoutName;
 import seedu.zerotoone.model.workout.WorkoutName;
@@ -23,8 +25,11 @@ public class FindCommand extends WorkoutCommand {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
         PredicateFilterWorkoutName predicate = new PredicateFilterWorkoutName(workoutName.fullName);
 
         model.updateFilteredWorkoutList(predicate);

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/ListCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/ListCommand.java
@@ -3,7 +3,9 @@ package seedu.zerotoone.logic.commands.workout;
 import static java.util.Objects.requireNonNull;
 import static seedu.zerotoone.model.Model.PREDICATE_SHOW_ALL_WORKOUTS;
 
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
+import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
 
 /**
@@ -15,8 +17,11 @@ public class ListCommand extends WorkoutCommand {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
         model.updateFilteredWorkoutList(PREDICATE_SHOW_ALL_WORKOUTS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/exercise/AddCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/exercise/AddCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -40,6 +41,10 @@ public class AddCommand extends WorkoutExerciseCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
+
         List<Workout> lastShownWorkoutList = model.getFilteredWorkoutList();
         List<Exercise> lastShownExerciseList = model.getFilteredExerciseList();
 

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/exercise/DeleteCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/exercise/DeleteCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -40,6 +41,9 @@ public class DeleteCommand extends WorkoutExerciseCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
 
         List<Workout> lastShownWorkoutList = model.getFilteredWorkoutList();
 

--- a/src/main/java/seedu/zerotoone/logic/commands/workout/exercise/EditCommand.java
+++ b/src/main/java/seedu/zerotoone/logic/commands/workout/exercise/EditCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.zerotoone.commons.core.Messages;
 import seedu.zerotoone.commons.core.index.Index;
+import seedu.zerotoone.logic.commands.Command;
 import seedu.zerotoone.logic.commands.CommandResult;
 import seedu.zerotoone.logic.commands.exceptions.CommandException;
 import seedu.zerotoone.model.Model;
@@ -44,6 +45,9 @@ public class EditCommand extends WorkoutExerciseCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isInSession()) {
+            throw new CommandException(Command.MESSAGE_SESSION_STARTED);
+        }
 
         List<Workout> lastShownWorkoutList = model.getFilteredWorkoutList();
         if (workoutId.getZeroBased() >= lastShownWorkoutList.size()) {


### PR DESCRIPTION
Allows for cleaner UX. No editing of exercises or workouts during a session to cause potential mishaps with the back-end data. For simplicity, we disable ALL commands so that the app has more predictable behaviour.