### PR TITLE
fix image paths so that PPP don't break (ONLY ONE COMMIT AHEAD of #233)

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -4,7 +4,7 @@
 :toc-title:
 :toc-placement: preamble
 :sectnums:
-:imagesDir: images/developer-guide
+:imagesDir: images/
 :stylesDir: stylesheets
 :xrefstyle: full
 ifdef::env-github[]
@@ -27,7 +27,7 @@ Refer to the guide <<SettingUp#, here>>.
 === Architecture
 
 .Architecture Diagram
-image::common/ArchitectureDiagram.png[]
+image::developer-guide/common/ArchitectureDiagram.png[]
 
 The *_Architecture Diagram_* given above explains the high-level design of the App. Given below is a quick overview of each component.
 
@@ -56,7 +56,7 @@ Each of the four components
 For example, the `Logic` component (see the class diagram given below) defines it's API in the `Logic.java` interface and exposes its functionality using the `LogicManager.java` class.
 
 .Class Diagram of the Logic Component
-image::common/LogicClassDiagram.png[]
+image::developer-guide/common/LogicClassDiagram.png[]
 
 [discrete]
 ==== How the architecture components interact with each other
@@ -64,14 +64,14 @@ image::common/LogicClassDiagram.png[]
 The _Sequence Diagram_ below shows how the components interact with each other for the scenario where the user issues the command `exercise delete 1`.
 
 .Component interactions for `exercise delete 1` command
-image::common/ArchitectureSequenceDiagram.png[]
+image::developer-guide/common/ArchitectureSequenceDiagram.png[]
 
 The sections below give more details of each component.
 
 [[Design-Main]]
 === Main Component
 .Structure of the Main Component
-image::common/MainClassDiagram.png[]
+image::developer-guide/common/MainClassDiagram.png[]
 
 *API* : link:{codeURL}/src/main/java/seedu/zerotoone/Main.java[`Main.java`]
 
@@ -85,7 +85,7 @@ During the GUI start up process, the `SplashScreen` will first load on a `Thread
 === UI Component
 
 .Structure of the UI Component
-image::common/UiClassDiagram.png[]
+image::developer-guide/common/UiClassDiagram.png[]
 
 *API* : link:{codeURL}/src/main/java/seedu/zerotoone/ui/Ui.java[`Ui.java`]
 
@@ -102,7 +102,7 @@ For more information about each component, check out the 'Implementation' sectio
 
 [[fig-LogicClassDiagram]]
 .Structure of the Logic Component
-image::common/LogicClassDiagram.png[]
+image::developer-guide/common/LogicClassDiagram.png[]
 
 *API* :
 link:{codeURL}/src/main/java/seedu/zerotoone/logic/Logic.java[`Logic.java`]
@@ -119,7 +119,7 @@ Inside the `Logic` package, there are some utility classes such as the `Argument
 Given below is the Sequence Diagram for interactions within the `Logic` component for the `execute("delete 1")` API call.
 
 .Interactions Inside the Logic Component for the `delete 1` Command
-image::common/DeleteSequenceDiagram.png[]
+image::developer-guide/common/DeleteSequenceDiagram.png[]
 
 NOTE: The lifeline for `ExerciseCommandParser` and `DeleteCommandParser` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline reaches the end of diagram.
 
@@ -129,7 +129,7 @@ For more information about each component, check out the 'Implementation' sectio
 === Model Component
 
 .Structure of the Model Component
-image::common/ModelClassDiagram.png[]
+image::developer-guide/common/ModelClassDiagram.png[]
 
 *API* : link:{codeURL}/src/main/java/seedu/zerotoone/model/Model.java[`Model.java`]
 
@@ -149,7 +149,7 @@ For more information about each component, check out the 'Implementation' sectio
 === Storage Component
 
 .Structure of the Storage Component
-image::common/StorageClassDiagram.png[]
+image::developer-guide/common/StorageClassDiagram.png[]
 
 *API* : link:{codeURL}/src/main/java/seedu/zerotoone/storage/Storage.java[`Storage.java`]
 
@@ -181,7 +181,7 @@ The Session feature resides on the Home page and is comprised of `Start`, `Stop`
 The activity diagram below demonstrates the actions of a user with this feature.
 
 .Session Feature Activity Diagram
-image::session/StartStopActivityDiagram.png[]
+image::developer-guide/session/StartStopActivityDiagram.png[]
 
 Start depicts the start of a valid (non-zero sets remaining) Workout Session.
 Upon depletion of all remaining sets, the `OngoingWorkout` automatically stops and produces a `CompletedWorkout` which is saved.
@@ -206,7 +206,7 @@ The inner workings of the feature are briefly expounded below through example us
 
 
 .Example Workout Session
-image::session/sessionExample.png[]
+image::developer-guide/session/sessionExample.png[]
 
 Step 1. The user selects an existing `Workout` called `Arms Day` with ID = `2` and starts a completedExercise with `start 2`.
 
@@ -223,7 +223,7 @@ updates the instance of `OngoingWorkout`.
 * The rest timer resets and starts counting from 00:00.
 
 .DoneCommand sequence diagram
-image::session/DoneCommandSequenceDiagram.png[]
+image::developer-guide/session/DoneCommandSequenceDiagram.png[]
 
 * The sequence diagram above demonstrates the interaction between the Logic and Model of ZeroToOne.
 For brevity, some inner details between `OngoingWorkout.done()` and the return of `cs` are omitted.
@@ -266,7 +266,7 @@ The following portion will explain in-detail each component of the Exercise feat
 
 ===== Model
 .Exercise Model Structure
-image::exercise/ExerciseModelClassDiagram.png[]
+image::developer-guide/exercise/ExerciseModelClassDiagram.png[]
 
 The figure above depicts the Model of the Exercise feature. Starting from the most primitive type:
 
@@ -283,7 +283,7 @@ Do note that some of the `Exercise` objects in the `ExerciseList` are also refer
 
 ===== Storage
 .Exercise Storage Structure
-image::exercise/ExerciseStorageClassDiagram.png[]
+image::developer-guide/exercise/ExerciseStorageClassDiagram.png[]
 
 The Storage component provides the functionalities that enable the persistent storage of the model. Starting from the most primitive type:
 
@@ -294,7 +294,7 @@ The Storage component provides the functionalities that enable the persistent st
 
 ===== Logic - Commands
 .Exercise Commands Structure
-image::exercise/ExerciseCommandClassDiagram.png[]
+image::developer-guide/exercise/ExerciseCommandClassDiagram.png[]
 
 The Exercise Commands package stores the business logic of the exercise feature. The commands are organised in a hierarchical fashion, in the order of precedence in a valid input. For example, `SetCommand` inherits from `ExerciseCommand` as the `set` comes after `exercise` in the input `exercise set`.
 
@@ -302,7 +302,7 @@ Each command contains a `COMMAND_WORD` which is a single word that is unique to 
 
 ===== Logic - Parsers
 .Exercise Parser Structure
-image::exercise/ExerciseParserClassDiagram.png[]
+image::developer-guide/exercise/ExerciseParserClassDiagram.png[]
 
 The parsers are responsible for parsing a user input into a `Command` object. For the Exercise component, there are parsers for every command that accepts user arguments. For example, since `exercise list` does not take in any argument, there is no parser for the `ListCommand`. After parsing the user input, the parser will return `Command` object to the caller, which will execute the command via the `execute` method.
 
@@ -310,7 +310,7 @@ The parsers are responsible for parsing a user input into a `Command` object. Fo
 This section will illustrate an example of an exercise command execution using the input `exercise create e/Bench Press`.
 
 .Exercise's CreateCommand Sequence Diagram
-image::exercise/CreateCommandSequenceDiagram.png[]
+image::developer-guide/exercise/CreateCommandSequenceDiagram.png[]
 
 In this portion, we will trace the sequence diagram of the `exercise create` command to better understand the internals of the Exercise feature.
 
@@ -331,7 +331,7 @@ In this portion, we will trace the sequence diagram of the `exercise create` com
 
 ===== Summary
 .Editing Exercise Set Activity Diagram
-image::exercise/EditSetActivityDiagram.png[]
+image::developer-guide/exercise/EditSetActivityDiagram.png[]
 
 At this point, you should have gather enough information to start developing the Exercise feature. As a summary, this is a sample Activity Diagram that depicts a user flow when they want to edit an exercise set.
 
@@ -360,7 +360,7 @@ Each workout consists of a `WorkoutId`, a `WorkoutName` and finally, an `Workout
 The following class diagram shows the overview of the Workout Manager:
 
 .Workout Class Diagram
-image::workout/WorkoutClassDiagram.png[]
+image::developer-guide/workout/WorkoutClassDiagram.png[]
 
 ==== Workout Model
 ZeroToOne's `Model` extends the `WorkoutModel`. Here are all the functions to carry out workout-related activities:
@@ -383,7 +383,7 @@ To illustrate an example of a command from the Workout Manager, the following se
 depicts flow of the program when the command `workout find w/Arms Workout` is run.
 
 .Sequence Diagram for Finding a Workout
-image::workout/WorkoutSequenceDiagram.png[]
+image::developer-guide/workout/WorkoutSequenceDiagram.png[]
 
 . When the user runs the command `workout find w/Arms Workout`, the `LogicManager` will first take in the command, by calling the `execute()` function on it.
 . The `ParserManager` then has to `parse("workout find w/Arms Workout")`.
@@ -425,7 +425,7 @@ The schedule feature in ZeroToOne allows users to plan their workouts! Users wil
 The following class diagram shows the overview of the `Scheduler`:
 
 .Scheduler Class Diagram
-image::schedule/ModelScheduleClassDiagram.png[]
+image::developer-guide/schedule/ModelScheduleClassDiagram.png[]
 
 As seen in the diagram above, The `Scheduler` consists two lists, `ScheduleList` and `ScheduledWorkoutList`.
 
@@ -462,7 +462,7 @@ ZeroToOne’s `Model` extends the `SchedulerModel`. Here are all the functions t
 To illustrate an example of a command from the `Scheduler`, the following sequence diagram depicts flow of the program when the command `schedule create 1 d/2020-04-01 14:00` is run.
 
 .Sequence Diagram for Creating a Schedule
-image::schedule/ScheduleCreateSequenceDiagram.png[]
+image::developer-guide/schedule/ScheduleCreateSequenceDiagram.png[]
 
 . When the user runs the command `schedule create 1 d/2020-04-01 14:00`, the `LogicManager` will first take in the command, by calling the `execute()` function on it.
 . The `ParserManager` then has to `parse("schedule create 1 d/2020-04-01 14:00")`.
@@ -480,7 +480,7 @@ NOTE: Date and time must not be outdated and follow the format {yyyy}-{mm}-{dd} 
 And the following sequence diagram shows how the `ScheduledWorkoutList` is populated after the method `Model#addSchedule(schedule)` is called:
 
 .Sequence Diagram for Populating `SortedScheduledWorkoutList`
-image::schedule/PopulateSortedScheduledWorkoutList.png[]
+image::developer-guide/schedule/PopulateSortedScheduledWorkoutList.png[]
 
 . After the `LogicManager` calls the method `Model#addSchedule(schedule)`, `ModelManager` calls `Scheduler#addSchedule(schedule)`, which in turns calls `ScheduleList#addSchedule(schedule)` and adds the `Schedule` in the `ScheduleList`.
 . The `Scheduler` will then populate the `ScheduledWorkoutList` by calling the method `populateSortedScheduledWorkoutList()`.
@@ -523,7 +523,7 @@ For logging, we propose saving the completedExercise data in the following class
 
 ==== Implementation
 
-image::log/WorkoutSessionDiagram.png[]
+image::developer-guide/log/WorkoutSessionDiagram.png[]
 
 ==== Design Considerations
 Immutability was a huge consideration for us and hence we came up with the `ReadOnly` interface.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -4,7 +4,7 @@
 :toc-title:
 :toc-placement: preamble
 :sectnums:
-:imagesDir: images/user-guide
+:imagesDir: images/
 :stylesDir: stylesheets
 :xrefstyle: full
 :experimental:
@@ -69,7 +69,7 @@ To start your ZeroToOne journey, you will have to:
 . Double-click the executable file to start the application.
 
 .ZeroToOne Main Page
-image::UgMainPage.png[]
+image::user-guide/UgMainPage.png[]
 
 At this stage, you should have successfully started ZeroToOne and will be able see the main page as described in Figure 1. If the application did not start, please refer to <<Troubleshooting>> for more information to resolve the issue. Otherwise, the next step is to begin your ZeroToOne journey, by customising your favourite workout programmes!
 
@@ -78,7 +78,7 @@ At this stage, you should have successfully started ZeroToOne and will be able s
 Before we delve into the commands that you can use, let us first explain the components of the User Interface, and how we can navigate through them.
 
 .Components of the User Interface
-image::UgUiComponents.png[]
+image::user-guide/UgUiComponents.png[]
 
 === Navigation Tabs
 The navigation tabs allow you to easily access different parts of our application. Simply click on each tab to bring you to your desired feature! The coloured underline indicates which tab is currently activated and hence which feature you are currently accessing.
@@ -116,7 +116,7 @@ help
 ```
 
 .Help Window
-image::UgHelp.png[]
+image::user-guide/UgHelp.png[]
 
 A pop-up window will appear, showing you a list of all available commands that you can try.
 
@@ -146,7 +146,7 @@ start 1
 ```
 
 .Started Workout
-image::UgStartWorkout.png[]
+image::user-guide/UgStartWorkout.png[]
 
 The User Interface will automatically switch to the “Home” tab. ZeroToOne will start displaying every exercise set in your workout, guiding you through set by set in your workout.
 
@@ -164,7 +164,7 @@ done
 ```
 
 .Done Set
-image::UgDoneSet.png[]
+image::user-guide/UgDoneSet.png[]
 
 The background color of the completed set will turn green in a few seconds, indicating that the set is successfully completed. ZeroToOne will then progress your workout forward, by starting on the next set. If you are already on your last set, ZeroToOne will automatically stop the workout completedExercise after this command is executed.
 
@@ -176,7 +176,7 @@ skip
 ```
 
 .Skipped Set
-image::UgSkippedSet.png[]
+image::user-guide/UgSkippedSet.png[]
 
 The background color of the completed set will turn red for a few seconds, indicating that the set is incomplete. ZeroToOne will then progress your workout forward, by starting on the next set. If you are already on your last set, ZeroToOne will automatically stop the workout completedExercise after this command is executed.
 
@@ -210,7 +210,7 @@ exercise create e/Bench Press
 ```
 
 .Created Exercise
-image::UgCreatedExercise.png[]
+image::user-guide/UgCreatedExercise.png[]
 
 The newly created exercise will be automatically added to the bottom of the exercise list. This exercise will not contain any sets at this point.
 
@@ -233,7 +233,7 @@ exercise set add 2 r/2 m/30
 ```
 
 .Added Exercise Set
-image::UgAddedExerciseSet.png[]
+image::user-guide/UgAddedExerciseSet.png[]
 
 The exercise set will be automatically appended to the current list of sets in the exercise. The user interface will be updated to show the edited exercise.
 
@@ -304,7 +304,7 @@ exercise list
 ```
 
 .Exercise List
-image::UgExerciseList.png[]
+image::user-guide/UgExerciseList.png[]
 
 The User Interface will automatically switch to the “Exercise” tab, and the result display will automatically update with the list of exercises (Figure 6).
 
@@ -324,7 +324,7 @@ exercise find e/Bench Press
 The Result Display will automatically update to only show exercises that match the search keyword.
 
 .Find Exercise
-image::UgFindExercise.png[]
+image::user-guide/UgFindExercise.png[]
 
 ```
 NOTE:
@@ -401,7 +401,7 @@ workout create w/Abs Workout
 ```
 
 .Creating A Workout
-image::UgCreateWorkout.png[]
+image::user-guide/UgCreateWorkout.png[]
 
 The feedback display will let you know if the creation of your workout was successful. The application view will also update to display your new workout!
 
@@ -490,7 +490,7 @@ workout list
 ```
 
 .Workout List
-image::UgWorkoutList.png[]
+image::user-guide/UgWorkoutList.png[]
 
 ZeroToOne will show you a list of all the workouts you have created! From this list, you can see the names of all your workouts, as well as their corresponding workout IDs.
 
@@ -508,7 +508,7 @@ workout find w/Strength Training
 ```
 
 .Find Workout
-image::UgFindWorkout.png[]
+image::user-guide/UgFindWorkout.png[]
 
 ZeroToOne will return a list of all the workouts whose name matches the workout name you have typed into the command. From this command, you can find out the workout ID number of the workout you are looking for, as well as see the details of each exercise in the workout.
 
@@ -623,7 +623,7 @@ schedule create 1 d/2020-05-06 18:00
 ```
 
 .Scheduling a workout session
-image::schedule/UgScheduleSession.png[]
+image::user-guide/schedule/UgScheduleSession.png[]
 
 ```
 NOTE:
@@ -640,7 +640,7 @@ schedule list
 ```
 
 .Display of schedule in chronological order
-image::schedule/UgListSchedule.png[]
+image::user-guide/schedule/UgListSchedule.png[]
 
 ZeroToOne displays an intuitive chronological view, showing your upcoming schedule! From this view, you can see what workout sessions are coming up, which workout sessions are outdated, as well as their corresponding schedule IDs.
 
@@ -731,7 +731,7 @@ log list
 ```
 
 .List of logged workout completedExercises
-image::UgLogList.png[]
+image::user-guide/UgLogList.png[]
 
 ZeroToOne will display a list of all the logged workout completedExercises you have carried out. Here, you can see all the logged completedExercises as well as their corresponding log ID number.
 
@@ -807,7 +807,7 @@ NOTE:
 ```
 
 .Graphical view of logs
-image::UgGraphicalLogs.png[]
+image::user-guide/UgGraphicalLogs.png[]
 
 ZeroToOne will display a graphical line chart that depicts your overall progress. This means you can quickly see at a glance how successful you have been in completing your completedExercises. This can help motivate you to work harder to improve, or continue maintaining your progress.
 


### PR DESCRIPTION
NOTE: This PR is only one commit ahead of #233 

Adoc not smart enough to recursively look up the correct image path when using include

so when you use include in PPP, the images from UG, and DG can't be parsed correctly because it's using the image path specified in  PPP only, and I don't think you can specify two separate image directory in adoc. 

this essentially requires UG DG PPP all have the same imageDir (`:imagesDir: images/`), to make everything display correctly. 

The solve I m proposing: 
1. keep the current structure of image folders
2. PPP, UG, and DG all use the same imageDir `:imagesDir: images/`
3. change every reference of image to something like 
* image::user-guide/schedule/UgListSchedule.png[]
* image::developer-guide/session/DoneCommandSequenceDiagram.png[]

Check out my last commit if you still don't get it https://github.com/AY1920S2-CS2103T-W16-2/main/commit/ef743340c2409d6cbe151cf1f46a2c3f5e68f8ae